### PR TITLE
feat: expose read-only WebMCP tools to AI agents

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,7 @@
 
   <!-- Custom ScrollSpy - no dependencies -->
   <script src="js/components.js" defer></script>
+  <script src="js/webmcp.js" defer></script>
 
 
 

--- a/js/webmcp.js
+++ b/js/webmcp.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview WebMCP tool provider for the portfolio site.
+ *
+ * Exposes a small set of read-only tools to AI agents / browser assistants
+ * via the W3C WebMCP API (navigator.modelContext), shipping experimentally in
+ * Chrome 146+. The whole module is a no-op where the API is absent, so it costs
+ * nothing on unsupported browsers and degrades gracefully.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/
+ */
+
+(function registerWebMcpTools() {
+  // Feature detection — bail out silently on unsupported browsers.
+  if (!('modelContext' in navigator) ||
+      typeof navigator.modelContext.registerTool !== 'function') {
+    return;
+  }
+
+  /** Canonical contact channels for Ján Dugovič. */
+  const CONTACT = {
+    name: 'Ján Dugovič',
+    role: 'Product Designer · Design Systems specialist',
+    email: 'dugovicjan@gmail.com',
+    signal: 'https://signal.me/#eu/pxHL83IAqb4Ti4ZFfAOG8mvGjI1g-pn-bTDOHaunKNNm4DDVH2VOx7l8soUGkvHK',
+    signalHandle: '@jd_ntk.42',
+    linkedin: 'https://www.linkedin.com/in/dugi/',
+    github: 'https://github.com/demoklion/jandu',
+    website: 'https://jandu.top/'
+  };
+
+  /** Portfolio case studies. Keep in sync with the "Work" section of index.html. */
+  const PROJECTS = [
+    {
+      title: 'Golem Design System',
+      url: 'https://jandu.top/project1.html',
+      summary: "Major design system to support a bank's new services offering. Covers target, role, and artifacts."
+    },
+    {
+      title: 'Začni učit!',
+      url: 'https://jandu.top/project2.html',
+      summary: 'Complex web app for an education NGO. Covers target, role, and artifacts.'
+    },
+    {
+      title: 'HeO',
+      url: 'https://jandu.top/project3.html',
+      summary: 'ERP software redesign. Covers problem, barriers, process, and result.'
+    }
+  ];
+
+  navigator.modelContext.registerTool({
+    name: 'get_contact_info',
+    title: 'Contact Ján Dugovič',
+    description: 'Returns the preferred ways to contact Ján Dugovič (email, Signal, LinkedIn, GitHub).',
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: 'object', properties: {} },
+    execute: async () => ({
+      content: [{ type: 'text', text: JSON.stringify(CONTACT) }]
+    })
+  });
+
+  navigator.modelContext.registerTool({
+    name: 'list_projects',
+    title: 'List portfolio projects',
+    description: 'Lists the portfolio case studies with title, one-line summary, and URL.',
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: 'object', properties: {} },
+    execute: async () => ({
+      content: [{ type: 'text', text: JSON.stringify(PROJECTS) }]
+    })
+  });
+})();

--- a/project1.html
+++ b/project1.html
@@ -304,6 +304,7 @@
 
   <!-- No ScrollSpy needed on project pages - clean -->
   <script src="js/components.js" defer></script>
+  <script src="js/webmcp.js" defer></script>
 
 
 

--- a/project2.html
+++ b/project2.html
@@ -262,6 +262,7 @@
 
   <!-- Custom JavaScript - Bootstrap Replacement -->
   <script src="js/components.js" defer></script>
+  <script src="js/webmcp.js" defer></script>
 
 
 

--- a/project3.html
+++ b/project3.html
@@ -374,6 +374,7 @@
 
   <!-- No ScrollSpy needed on project pages - clean -->
   <script src="js/components.js" defer></script>
+  <script src="js/webmcp.js" defer></script>
 
 
 


### PR DESCRIPTION
## What

Adds [WebMCP](https://webmachinelearning.github.io/webmcp/) support to the portfolio so AI agents and browser assistants can call site features directly via `navigator.modelContext`.

New `js/webmcp.js` registers two **read-only** tools:

- `get_contact_info` — preferred contact channels (email, Signal, LinkedIn, GitHub)
- `list_projects` — the three case studies with title, summary, and URL

Wired into `index.html` and `project[1-3].html` after `components.js`.

## Why

WebMCP became a W3C Draft Community Group Report (2026-02-10) and ships experimentally in Chrome 146. Exposing tools is an on-brand, forward-looking demo of the agentic web for a design-systems portfolio.

## Notes

- **Zero cost where unsupported**: the module feature-detects `navigator.modelContext` and is a complete no-op otherwise. No new dependency, no build step.
- Requires HTTPS / secure context (satisfied by GitHub Pages).
- Project/contact data is hardcoded in the module and must be kept in sync with the "Work" and contact sections of `index.html`.
- Pure JS — no CSS changes, so the visual-regression baseline is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)